### PR TITLE
Update PimpleDumpProvider.php

### DIFF
--- a/src/PimpleDumpProvider.php
+++ b/src/PimpleDumpProvider.php
@@ -40,6 +40,10 @@ class PimpleDumpProvider implements ControllerProviderInterface, ServiceProvider
             if ($name === 'dump.path') {
                 continue;
             }
+            
+            if ($name === 'security') {
+                continue;
+            }
 
             if ($item = $this->parseItem($container, $name)) {
                 $map[] = $item;


### PR DESCRIPTION
it gives this error if we don't exclude `$app['security']`:

```
( ! ) Fatal error: Class 'Symfony\Component\Security\Core\SecurityContext' not found in /var/www/OptDoc/vendor/silex/silex/src/Silex/Provider/SecurityServiceProvider.php on line 91
```
